### PR TITLE
修正多个v-echarts指令，无法自动resize的问题

### DIFF
--- a/src/directives/echarts.js
+++ b/src/directives/echarts.js
@@ -28,17 +28,9 @@ module.exports = {
             }
 
             // auto resize
-            var resizeEvent = new Event('resize');
-
-            _this.resizeEventHandler = function () {
+            window..addEventListener('resize', function (event) {
                 _this.instance.resize();
-            };
-
-            _this.el.addEventListener('resize', _this.resizeEventHandler, false);
-
-            window.onresize = function () {
-                _this.el.dispatchEvent(resizeEvent);
-            };
+            });
         });
     },
     update: function (val, oldVal) {


### PR DESCRIPTION
在同一个组件里出现多个指令，只有最后一个指令会响应resize事件，其他指令毫无反应。因为window.onsize被重复覆盖了，现在添加事件监听resize，能解决这个问题
